### PR TITLE
Fixes ExtensionManagementUtility error and enables multi owl-sliders on one page

### DIFF
--- a/Configuration/FlexForms/flexform_owlslider.xml
+++ b/Configuration/FlexForms/flexform_owlslider.xml
@@ -11,23 +11,31 @@
         		<type>array</type>
         		<el>
         			<settings.slidertype>
-   						<TCEforms>
-    						<label></label>
-    						<config>
-     							<type>select</type>
-      							<items type="array">
-									<numIndex index="0" type="array">
-										<numIndex index="0">Simple Owl</numIndex>
-										<numIndex index="1">1</numIndex>
-									</numIndex>
-									<numIndex index="1" type="array">
-										<numIndex index="0">Synced Owls</numIndex>
-										<numIndex index="1">2</numIndex>
-									</numIndex>
-								</items>
-    						</config>
+   					<TCEforms>
+	    					<label></label>
+	    					<config>
+	     						<type>select</type>
+	      						<items type="array">
+								<numIndex index="0" type="array">
+									<numIndex index="0">Simple Owl</numIndex>
+									<numIndex index="1">1</numIndex>
+								</numIndex>
+								<numIndex index="1" type="array">
+									<numIndex index="0">Synced Owls</numIndex>
+									<numIndex index="1">2</numIndex>
+								</numIndex>
+							</items>
+	    					</config>
     					</TCEforms>
- 					</settings.slidertype>
+ 				</settings.slidertype>
+ 				<settings.slider_id>
+   					<TCEforms>
+	    					<label>Slider ID (only required if more then 1 Slider is used)</label>
+	    					<config>
+	     						<type>input</type>
+	    					</config>
+	    				</TCEforms>
+ 				</settings.slider_id>
         		</el>
         	</ROOT>
         </sDEF>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -22,7 +22,9 @@
 			<trans-unit id="tx_owlslider_domain_model_item.slidertype">
 				<source>Slider Type</source>
 			</trans-unit>
-
+			<trans-unit id="tx_owlslider_domain_model_item.slideroptions">
+				<source>Slider Options</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Partials/SimpleOwl.html
+++ b/Resources/Private/Partials/SimpleOwl.html
@@ -1,6 +1,6 @@
 {namespace owl=TYPO3\OwlSlider\ViewHelpers}
 
-<div id="owlslider" class="owl-carousel owl-theme">
+<div id="owlslider_{settings.slider_id}" class="owl-carousel owl-theme">
 	<f:for each="{items}" as="item">
 		<div class="item">
 			<f:if condition="{item.itemimage}">
@@ -27,7 +27,7 @@
 
 <owl:addJsFooterInlineCode name="owlslider" >
 	jQuery(document).ready(function() {
-		var slider = jQuery('#owlslider');
+		var slider = jQuery('#owlslider_{settings.slider_id}');
 		slider.owlCarousel({
 			items : <f:format.raw value="{settings.items}" />,
 			itemsDesktop : <f:format.raw value="{settings.itemsDesktop}" />,
@@ -65,10 +65,10 @@
 			transitionStyle : <f:format.raw value="{settings.transitionStyle}" />,
 		});
 		// Custom Navigation
-		jQuery(".next").click(function() {
+		jQuery(".customNavigation_{settings.slider_id} .next").click(function() {
 			slider.trigger('owl.next');
 		})
-		jQuery(".prev").click(function() {
+		jQuery(".customNavigation_{settings.slider_id} .prev").click(function() {
 			slider.trigger('owl.prev');
 		})
 	});

--- a/Resources/Private/Partials/SimpleOwl.html
+++ b/Resources/Private/Partials/SimpleOwl.html
@@ -25,7 +25,7 @@
 	<f:render partial="SliderNavigation" />
 </f:if>
 
-<owl:addJsFooterInlineCode name="owlslider" >
+<owl:addJsFooterInlineCode name="owlslider_{settings.slider_id}" >
 	jQuery(document).ready(function() {
 		var slider = jQuery('#owlslider_{settings.slider_id}');
 		slider.owlCarousel({

--- a/Resources/Private/Partials/SimpleOwl.html
+++ b/Resources/Private/Partials/SimpleOwl.html
@@ -27,7 +27,7 @@
 
 <owl:addJsFooterInlineCode name="owlslider" >
 	jQuery(document).ready(function() {
-		var slider = $('#owlslider');
+		var slider = jQuery('#owlslider');
 		slider.owlCarousel({
 			items : <f:format.raw value="{settings.items}" />,
 			itemsDesktop : <f:format.raw value="{settings.itemsDesktop}" />,
@@ -65,10 +65,10 @@
 			transitionStyle : <f:format.raw value="{settings.transitionStyle}" />,
 		});
 		// Custom Navigation
-		$(".next").click(function() {
+		jQuery(".next").click(function() {
 			slider.trigger('owl.next');
 		})
-		$(".prev").click(function() {
+		jQuery(".prev").click(function() {
 			slider.trigger('owl.prev');
 		})
 	});

--- a/Resources/Private/Partials/SliderNavigation.html
+++ b/Resources/Private/Partials/SliderNavigation.html
@@ -1,4 +1,4 @@
-<div class="customNavigation">
+<div class="customNavigation_{settings.slider_id}">
 	<a class="btn prev">
 		<i class='icon-chevron-left icon-white'></i>
 	</a>

--- a/Resources/Private/Partials/SyncedOwls.html
+++ b/Resources/Private/Partials/SyncedOwls.html
@@ -32,9 +32,9 @@
 
 
 <owl:addJsFooterInlineCode name="owlslider" >
-	$(document).ready(function() {
-    	var sync1 = $("#sync1");
-    	var sync2 = $("#sync2");
+	jQuery(document).ready(function() {
+    	var sync1 = jQuery("#sync1");
+    	var sync2 = jQuery("#sync2");
      
     	sync1.owlCarousel({
     		items : 1,
@@ -116,20 +116,20 @@
      
 	    function syncPosition(el){
 		    var current = this.currentItem;
-		    $("#sync2")
+		    jQuery("#sync2")
 		    .find(".owl-item")
 		    .removeClass("synced")
 		    .eq(current)
 		    .addClass("synced")
 		    
-		    if($("#sync2").data("owlCarousel") !== undefined){
+		    if(jQuery("#sync2").data("owlCarousel") !== undefined){
 		    	center(current)
 	    	}
 	    }
      
-	    $("#sync2").on("click", ".owl-item", function(e){
+	    jQuery("#sync2").on("click", ".owl-item", function(e){
 		    e.preventDefault();
-		    var number = $(this).data("owlItem");
+		    var number = jQuery(this).data("owlItem");
 		    sync1.trigger("owl.goTo",number);
 	    });
 	     

--- a/Resources/Private/Partials/SyncedOwls.html
+++ b/Resources/Private/Partials/SyncedOwls.html
@@ -31,7 +31,7 @@
 
 
 
-<owl:addJsFooterInlineCode name="owlslider" >
+<owl:addJsFooterInlineCode name="owlslider_{settings.slider_id}" >
 	jQuery(document).ready(function() {
     	var sync1 = jQuery("#sync1_{settings.slider_id}");
     	var sync2 = jQuery("#sync2_{settings.slider_id}");
@@ -161,7 +161,7 @@
 	});
 	    
 	    window.onload = function() {
-	   		var anchorElements = document.getElementById('sync2').getElementsByTagName('a');
+	   		var anchorElements = document.getElementById('sync2_{settings.slider_id}').getElementsByTagName('a');
 	   		for (var i in anchorElements)
 	       	anchorElements[i].onclick = function() {
 	       		if(this.target === '') {

--- a/Resources/Private/Partials/SyncedOwls.html
+++ b/Resources/Private/Partials/SyncedOwls.html
@@ -1,6 +1,6 @@
 {namespace owl=TYPO3\OwlSlider\ViewHelpers}
 
-<div id="sync1" class="owl-carousel">
+<div id="sync1_{settings.slider_id}" class="owl-carousel">
 	<f:for each="{items}" as="item">
 		<div class="item">
 			<f:if condition="{item.itemimage}">
@@ -19,7 +19,7 @@
 		</div>
 	</f:for>
 </div>
-<div id="sync2" class="owl-carousel">
+<div id="sync2_{settings.slider_id}" class="owl-carousel">
 	<f:for each="{items}" as="item">
 		<f:if condition="{item.itemcontent}">
 			<div class="item">
@@ -33,8 +33,8 @@
 
 <owl:addJsFooterInlineCode name="owlslider" >
 	jQuery(document).ready(function() {
-    	var sync1 = jQuery("#sync1");
-    	var sync2 = jQuery("#sync2");
+    	var sync1 = jQuery("#sync1_{settings.slider_id}");
+    	var sync2 = jQuery("#sync2_{settings.slider_id}");
      
     	sync1.owlCarousel({
     		items : 1,
@@ -116,18 +116,18 @@
      
 	    function syncPosition(el){
 		    var current = this.currentItem;
-		    jQuery("#sync2")
+		    sync2
 		    .find(".owl-item")
 		    .removeClass("synced")
 		    .eq(current)
 		    .addClass("synced")
 		    
-		    if(jQuery("#sync2").data("owlCarousel") !== undefined){
+		    if(sync2.data("owlCarousel") !== undefined){
 		    	center(current)
 	    	}
 	    }
      
-	    jQuery("#sync2").on("click", ".owl-item", function(e){
+	    sync2.on("click", ".owl-item", function(e){
 		    e.preventDefault();
 		    var number = jQuery(this).data("owlItem");
 		    sync1.trigger("owl.goTo",number);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,4 @@
 <?php
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 if (!defined('TYPO3_MODE')) {
 	die ('Access denied.');


### PR DESCRIPTION
I just removed the ExtensionManagementUtility call from localconf to prevent the extension to throw an error if this call is already made. Which is at most cases. Otherwise there is autoloading of classes which also made this call obsolete.

Additionally I inserted an setting "slider_id" which is append on the id of the element in the dom. So you can use more than one slider at a page, which was not possible before because there only was one initialization.

Also I made it fully compatible if one is using other libraries than jQuery together with jQuery. 

Last but not least I removed some unnecessary dom calls. E.g.: call jQuery("#sync2") if it was declared as var syn2 = jQuery("#sync2"); before. You can use sync2 then!