### PR TITLE
Fix problem with missing plugin form fields (Flexform)

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -11,7 +11,7 @@ $extKey = 'owl_slider';
 
 $pluginSignature = str_replace('_', '', $extKey) . '_owlslider';
 
-$TCA['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignature] = 'pi_flexform';
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
     $pluginSignature,

--- a/Documentation/Changelog/Index.rst
+++ b/Documentation/Changelog/Index.rst
@@ -73,4 +73,5 @@ ChangeLog
 +----------------+---------------------------------------------------------------------------------+
 | 2.5.1          | fix naming for owlCarouselObjectPart.html partial                               |
 |                | fix broken demo links in documentation, migrate TCA and general cleanup         |
+|                | fix problem with missing plugin form fields (Flexform)                          |
 +----------------+---------------------------------------------------------------------------------+


### PR DESCRIPTION
The flexform fields in the plugin are missing in both TYPO3 v7 and v8.
This also means that the conditions like `<f:if condition="{settings.slidertype} == 1">` in the _List.html_ template can never true, so there's no rendering of items at all.

Using the global variable `$GLOBALS['TCA']` fixes these problems. As far as I understand, using the global notation is the recommended way in the newer TYPO3 versions.